### PR TITLE
Add getHeadersByHeight API (/api/v1/chain/header/byHeight)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -70,6 +70,16 @@ Retrieves the header with the given hash
 ```
 The content type: ```application/octet-stream``` can be provided in the requst header to return the headers raw bytes.
 
+#### Query Headers By Height (batched)
+Retrieves the header with the given hash
+```
+/api/v1/chain/header/byHeight?height=<start_height>&count=<count>
+```
+The Accept type: ```application/octet-stream``` can be provided in the requst header to return the headers as a 
+stream of raw bytes.
+
+The query parameter: height is required. The count of headers requested is optional (default = 1)
+
 #### Query Headers State
 Retrieves the header with the given hash along with it's state relative to the chain
 ```

--- a/src/main/java/io/bitcoinsv/headerSV/api/HSVFacade.java
+++ b/src/main/java/io/bitcoinsv/headerSV/api/HSVFacade.java
@@ -44,6 +44,30 @@ public class HSVFacade {
         return BlockHeaderDTO.of(blockHeader.get());
     }
 
+    public List<BlockHeaderDTO> getHeadersByHeight(Integer height, Integer count){
+        List<BlockHeaderDTO> listBlockHeaders = new ArrayList<>();
+        ChainInfo longestChainInfo = blockChainStore.getLongestChain().get();
+        HeaderReadOnly chainTip = longestChainInfo.getHeader();
+
+        // validation of inputs
+        int lastHeaderHeight = height + count - 1;
+        if (height > longestChainInfo.getHeight()) {
+            throw new IllegalArgumentException(String.format("Header at height %s exceeds the chain tip: %s", height, longestChainInfo.getHeight()));
+        } else if (lastHeaderHeight > longestChainInfo.getHeight()) {
+            lastHeaderHeight = longestChainInfo.getHeight();
+        }
+
+        for(int curHeight = height; curHeight<=lastHeaderHeight; curHeight++)
+        {
+            Optional<ChainInfo> header = blockChainStore.getAncestorByHeight(chainTip.getHash(), curHeight);
+            if (header.isEmpty()) {
+                throw new IllegalStateException(String.format("Header at height %s not found", curHeight));
+            }
+            listBlockHeaders.add(BlockHeaderDTO.of(header.get().getHeader()));
+        }
+        return listBlockHeaders;
+    }
+
     public List<BlockHeaderDTO> getAncestors(String hash, String ancestorHash){
         Optional<ChainInfo> requestedBlock = blockChainStore.getBlockChainInfo(Sha256Hash.wrap(hash));
         Optional<ChainInfo> ancestorBlock = blockChainStore.getBlockChainInfo(Sha256Hash.wrap(ancestorHash));

--- a/src/main/java/io/bitcoinsv/headerSV/api/v1/controller/BlockHeaderControllerV1.java
+++ b/src/main/java/io/bitcoinsv/headerSV/api/v1/controller/BlockHeaderControllerV1.java
@@ -62,7 +62,11 @@ public class BlockHeaderControllerV1 {
     public ResponseEntity<?> getHeadersByHeight(@RequestParam String height, @RequestParam(defaultValue = "1") String count,
                                                 @RequestHeader(value = "Accept", required = false, defaultValue = "application/json") MediaType acceptContentType){
         try {
-            List<BlockHeaderDTO> headers = hsvFacade.getHeadersByHeight(Integer.valueOf(height), Integer.valueOf(count));
+            if (Integer.parseInt(count) > 2000) {
+                throw new IllegalArgumentException("Count exceeds max value of 2000 headers");
+            }
+
+            List<BlockHeaderDTO> headers = hsvFacade.getHeadersByHeight(Integer.parseInt(height), Integer.parseInt(count));
             if (acceptContentType.toString().equals(MediaType.APPLICATION_OCTET_STREAM_VALUE)) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 for (BlockHeaderDTO header : headers) {

--- a/src/main/java/io/bitcoinsv/headerSV/api/v1/controller/BlockHeaderControllerV1.java
+++ b/src/main/java/io/bitcoinsv/headerSV/api/v1/controller/BlockHeaderControllerV1.java
@@ -10,6 +10,8 @@ import io.bitcoinsv.headerSV.api.HSVFacade;
 import io.bitcoinsv.headerSV.domain.dto.BlockHeaderDTO;
 import io.bitcoinsv.headerSV.domain.dto.ChainStateDTO;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -54,6 +56,27 @@ public class BlockHeaderControllerV1 {
         }
 
         return new ResponseEntity<>(headerHistory, HttpStatus.OK);
+    }
+
+    @RequestMapping("/byHeight")
+    public ResponseEntity<?> getHeadersByHeight(@RequestParam String height, @RequestParam(defaultValue = "1") String count,
+                                                @RequestHeader(value = "Accept", required = false, defaultValue = "application/json") MediaType acceptContentType){
+        try {
+            List<BlockHeaderDTO> headers = hsvFacade.getHeadersByHeight(Integer.valueOf(height), Integer.valueOf(count));
+            if (acceptContentType.toString().equals(MediaType.APPLICATION_OCTET_STREAM_VALUE)) {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                for (BlockHeaderDTO header : headers) {
+                    baos.write(header.getHeaderReadOnly().serialize());
+                }
+                return new ResponseEntity<>(baos.toByteArray(), HttpStatus.OK);
+            } else {
+                // MediaType.APPLICATION_JSON_VALUE
+                return new ResponseEntity<>(headers, HttpStatus.OK);
+            }
+        }
+        catch (IllegalArgumentException | IllegalStateException | IOException exception) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, exception.getMessage());
+        }
     }
 
     @RequestMapping("/commonAncestor")


### PR DESCRIPTION
Pull Request for discussion (as advised by Jad)

- takes url query parameters: height and count
- use 'Accept': application/octet-stream for a contiguous stream of 80 byte headers

Reasons for this PR:

ElectrumSV maintains its own memory mapped local headers cache which is beneficial for several reasons.
- It is low latency (it's an in-memory key-value lookup) as compared to a slow network call to HeaderSV.
- Allows for graceful reconciliation of edge case issues such as: powering down the wallet only to find we have a 6 month old orphaned merkle proof
- The `bitcoinx.Headers` library has ergonomic functionality we are already making use of in our codebase.
- We want to host HeaderSV remotely on a public `https://` API because direct tcp:// socket connections (such as what HeaderSV does) will not work in Airports, Cafes, Hotel rooms etc. It would also significantly complicate our build process for distribution of ElectrumSV binaries to try and incorporate a client side instance of the Java-based HeaderSV project.