### PR TITLE
Fix an issue with casting String type `Accept` header to MediaType

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -68,14 +68,14 @@ Retrieves the header with the given hash
 ```
 /api/v1/chain/header/{hash}
 ```
-The content type: ```application/octet-stream``` can be provided in the requst header to return the headers raw bytes.
+The Accept type: ```application/octet-stream``` can be provided in the request header to return the headers raw bytes.
 
 #### Query Headers By Height (batched)
 Retrieves the header with the given hash
 ```
 /api/v1/chain/header/byHeight?height=<start_height>&count=<count>
 ```
-The Accept type: ```application/octet-stream``` can be provided in the requst header to return the headers as a 
+The Accept type: ```application/octet-stream``` can be provided in the request header to return the headers as a 
 stream of raw bytes.
 
 The query parameter: height is required. The count of headers requested is optional (default = 1)

--- a/src/main/java/io/bitcoinsv/headerSV/api/v1/controller/BlockHeaderControllerV1.java
+++ b/src/main/java/io/bitcoinsv/headerSV/api/v1/controller/BlockHeaderControllerV1.java
@@ -32,26 +32,23 @@ public class BlockHeaderControllerV1 {
 
     @RequestMapping("/{hash}")
     public ResponseEntity<?> getHeader(@PathVariable String hash,
-                                       @RequestHeader(value = "Accept", required = false, defaultValue = "application/json") MediaType acceptContentType) {
+                                       @RequestHeader(value = "Accept", required = false, defaultValue = "application/json") String acceptContentType) {
         BlockHeaderDTO blockHeaderDTO = hsvFacade.getBlockHeader(hash);
 
         if (blockHeaderDTO == null) {
             throw new ResponseStatusException(HttpStatus.NO_CONTENT, "BlockHeader not found");
         }
 
-        switch (acceptContentType.toString()) {
-            case MediaType.APPLICATION_OCTET_STREAM_VALUE:
-                return ResponseEntity
-                        .ok()
-                        .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                        .body(blockHeaderDTO.getHeaderReadOnly().serialize());
-
-            default:
-                return ResponseEntity
-                        .ok()
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .body(blockHeaderDTO);
+        if (MediaType.APPLICATION_OCTET_STREAM_VALUE.equals(acceptContentType)) {
+            return ResponseEntity
+                    .ok()
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                    .body(blockHeaderDTO.getHeaderReadOnly().serialize());
         }
+        return ResponseEntity
+                .ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(blockHeaderDTO);
     }
 
     @RequestMapping("/{hash}/ancestors")
@@ -67,14 +64,14 @@ public class BlockHeaderControllerV1 {
 
     @RequestMapping("/byHeight")
     public ResponseEntity<?> getHeadersByHeight(@RequestParam String height, @RequestParam(defaultValue = "1") String count,
-                                                @RequestHeader(value = "Accept", required = false, defaultValue = "application/json") MediaType acceptContentType){
+                                                @RequestHeader(value = "Accept", required = false, defaultValue = "application/json") String acceptContentType){
         try {
             if (Integer.parseInt(count) > 2000) {
                 throw new IllegalArgumentException("Count exceeds max value of 2000 headers");
             }
 
             List<BlockHeaderDTO> headers = hsvFacade.getHeadersByHeight(Integer.parseInt(height), Integer.parseInt(count));
-            if (acceptContentType.toString().equals(MediaType.APPLICATION_OCTET_STREAM_VALUE)) {
+            if (acceptContentType.equals(MediaType.APPLICATION_OCTET_STREAM_VALUE)) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 for (BlockHeaderDTO header : headers) {
                     baos.write(header.getHeaderReadOnly().serialize());


### PR DESCRIPTION
- There were no issues in Postman or application code when only a single mime type is passed but in Chrome browser it uses `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9` as the `Accept` header and these comma-separated string values cannot be coerced to a single `MediaType`.

If you want to make this trivial change on the private repo and close this PR, I do not mind - just do whatever is easiest for you.